### PR TITLE
Extract talks and attachments from our Sched.com

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+requests
+tqdm

--- a/sched_talks.py
+++ b/sched_talks.py
@@ -23,4 +23,41 @@ class SchedTalks(object):
             self.json = json.load(f)
 
         for talk in tqdm(self.json, desc='Processing talks'):
+            # Process attachments
+            attachments = talk.get('files', [])
+            if attachments:
+                attachments_resolved = self._download_attachments(
+                    attachments
+                )
+                talk['attachments'] = attachments_resolved
+
             self.talks.append(talk)
+
+    def _download_attachments(self, attachments, destination_path=None):
+        """Helper to download and save files"""
+
+        result = []
+        for attachment in attachments:
+            file_url = attachment.get('path')
+            file_name = attachment.get('name')
+
+            if not file_name:
+                import pudb; pu.db
+
+            file_path_local = os.path.join(
+                destination_path or self.output_dir,
+                file_name
+            )
+            get_response = requests.get(file_url, stream=True)
+            with open(file_path_local, 'wb') as f:
+                for chunk in get_response.iter_content(chunk_size=1024):
+                    if chunk:
+                        f.write(chunk)
+
+            result.append({
+                'file_url': file_url,
+                'file_path': file_path_local,
+                'file_name': file_name,
+            })
+
+        return result

--- a/sched_talks.py
+++ b/sched_talks.py
@@ -1,6 +1,7 @@
+import os
 class SchedTalks(object):
     def __init__(self, **kwargs):
-        """Load settings"""
+        """Load settings and prepare paths"""
 
         self.settings = {
             'output_dir': 'files',
@@ -8,4 +9,10 @@ class SchedTalks(object):
         }
 
         self.talks = []
-    pass
+        
+        try:
+            os.mkdir(self.output_dir)
+        except FileExistsError:
+            pass
+
+

--- a/sched_talks.py
+++ b/sched_talks.py
@@ -103,3 +103,10 @@ class SchedTalks(object):
             })
 
         return result
+
+    def export_md(self, file_name="README.md"):
+        """Export as md file"""
+
+        with open(file_name, "w") as readme:
+            readme.write(self.as_md)
+

--- a/sched_talks.py
+++ b/sched_talks.py
@@ -1,5 +1,11 @@
 import os
+import json
+import requests
+from tqdm import tqdm
+
 class SchedTalks(object):
+    __slots__ = ['json', 'talks', 'settings']
+
     def __init__(self, **kwargs):
         """Load settings, prepare paths and get talks"""
 

--- a/sched_talks.py
+++ b/sched_talks.py
@@ -24,6 +24,38 @@ class SchedTalks(object):
         self._get_talks()
 
     @property
+    def as_md(self):
+        """
+        Render talks as a MD string
+
+        It skips non real talks i.e Coffe breaks, lunchs and other similar entries 
+        based on the speaker definition.
+        """
+
+        talks_content = ''
+        for talk in tqdm(self.talks, desc='Converting to MD'):
+            speakers = [speaker.get('name', 'Unknown')
+                        for speaker in talk.get('speakers', [])]
+
+            # Skip unnamed talks (coffee break, lunch, ...)
+            if not speakers:
+                continue
+
+            speakers_formated = ", ".join(speakers)
+            talk_md = f"\n- **'{talk.get('name')}'** by _{speakers_formated}_"
+
+            attachments = talk.get('attachments')
+            if attachments:
+                talk_md += ''.join([
+                    f'\n  - [{attachment.get("file_name")}]({attachment.get("file_path")})'
+                    for attachment in attachments
+                ])
+            
+            talks_content += talk_md
+
+        return talks_content
+     
+    @property
     def output_dir(self):
         return self.settings.get('output_dir')
 

--- a/sched_talks.py
+++ b/sched_talks.py
@@ -110,3 +110,7 @@ class SchedTalks(object):
         with open(file_name, "w") as readme:
             readme.write(self.as_md)
 
+
+if __name__ == "__main__":
+    talks = SchedTalks(output_dir='files')
+    talks.export_md(file_name='README.md')

--- a/sched_talks.py
+++ b/sched_talks.py
@@ -1,2 +1,11 @@
 class SchedTalks(object):
+    def __init__(self, **kwargs):
+        """Load settings"""
+
+        self.settings = {
+            'output_dir': 'files',
+            **kwargs,
+        }
+
+        self.talks = []
     pass

--- a/sched_talks.py
+++ b/sched_talks.py
@@ -17,6 +17,10 @@ class SchedTalks(object):
 
         self._get_talks()
 
+    @property
+    def output_dir(self):
+        return self.settings.get('output_dir')
+
     def _get_talks(self):
         """Load talks file and process it downloading associated files"""
         with open('talks.json') as f:

--- a/sched_talks.py
+++ b/sched_talks.py
@@ -1,7 +1,7 @@
 import os
 class SchedTalks(object):
     def __init__(self, **kwargs):
-        """Load settings and prepare paths"""
+        """Load settings, prepare paths and get talks"""
 
         self.settings = {
             'output_dir': 'files',
@@ -15,4 +15,12 @@ class SchedTalks(object):
         except FileExistsError:
             pass
 
+        self._get_talks()
 
+    def _get_talks(self):
+        """Load talks file and process it downloading associated files"""
+        with open('talks.json') as f:
+            self.json = json.load(f)
+
+        for talk in tqdm(self.json, desc='Processing talks'):
+            self.talks.append(talk)

--- a/sched_talks.py
+++ b/sched_talks.py
@@ -1,0 +1,2 @@
+class SchedTalks(object):
+    pass


### PR DESCRIPTION
It provides an Sched.com talks extractor.

Concretely, it creates a markdown file with all pycones2019 talks and their related stuff.

If any talk have attachments, those are downloaded and linked into the resultant file.